### PR TITLE
Watch doc mounted

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A component can also subscribe to changes with `$watch`.
 
 ```javascript
 class TodoItems extends El {
-  created() {
+  mounted() {
     this.$watch(store.items.length, () => console.log("length changed!"));
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -439,7 +439,7 @@ suite('main', async test => {
     assert.equal(css.replace(/\s+/g, ' '), 'ul li{ color: red; }')
   })
 
-  await test('watch-mounted', async () => {
+  await test('watch mounted', async () => {
     setup();
     let watched = false;
     class MyComponent extends El {

--- a/test/main.js
+++ b/test/main.js
@@ -459,26 +459,5 @@ suite('main', async test => {
     assert.equal(watched, true, 'watched becomes true')
     component.remove()
   })
-
-  await test('watch-created', async () => {
-    setup();
-    let watched = false;
-    class MyComponent extends El {
-      created() {
-        this.state = El.observable({ item: false })
-        this.$watch(this.state.item, () => {
-          watched = true;
-        });
-        this.state.item = true;
-     }
-    }
-    customElements.define('my-component', MyComponent)
-    const component = document.createElement('my-component')
-    assert.equal(watched, false, 'watched starts false')
-    document.body.appendChild(component)
-    await new Promise(r => setTimeout(r))
-    assert.equal(watched, true, 'watched becomes true')
-    component.remove()
-  })
 })
 

--- a/test/main.js
+++ b/test/main.js
@@ -438,5 +438,47 @@ suite('main', async test => {
     const css = atob(cssEl.shadowRoot.querySelector('link').href.split(',')[1])
     assert.equal(css.replace(/\s+/g, ' '), 'ul li{ color: red; }')
   })
+
+  await test('watch-mounted', async () => {
+    setup();
+    let watched = false;
+    class MyComponent extends El {
+      mounted() {
+        this.state = El.observable({ item: false })
+        this.$watch(this.state.item, () => {
+          watched = true;
+        });
+        this.state.item = true;
+     }
+    }
+    customElements.define('my-component', MyComponent)
+    const component = document.createElement('my-component')
+    assert.equal(watched, false, 'watched starts false')
+    document.body.appendChild(component)
+    await new Promise(r => setTimeout(r))
+    assert.equal(watched, true, 'watched becomes true')
+    component.remove()
+  })
+
+  await test('watch-created', async () => {
+    setup();
+    let watched = false;
+    class MyComponent extends El {
+      created() {
+        this.state = El.observable({ item: false })
+        this.$watch(this.state.item, () => {
+          watched = true;
+        });
+        this.state.item = true;
+     }
+    }
+    customElements.define('my-component', MyComponent)
+    const component = document.createElement('my-component')
+    assert.equal(watched, false, 'watched starts false')
+    document.body.appendChild(component)
+    await new Promise(r => setTimeout(r))
+    assert.equal(watched, true, 'watched becomes true')
+    component.remove()
+  })
 })
 


### PR DESCRIPTION
Tweak the `$watch` docs and add a test.

`created()` seems to be too early in the lifecycle to install watchers - this patch set adds a test and updates the documentation to install them in `mounted()`